### PR TITLE
Remove include for terraform documentation

### DIFF
--- a/README.yaml
+++ b/README.yaml
@@ -24,9 +24,6 @@ usage: |-
 
 
 
-include:
-  - "docs/terraform.md"
-
 tags:
   - terraform
   - terraform-modules


### PR DESCRIPTION
This pull request makes a minor update to the documentation configuration by removing the inclusion of the Terraform documentation file.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Documentation
  * Removed an outdated include referencing Terraform documentation to prevent broken or redundant links in the generated docs.
  * Streamlined the README content for clarity; no changes to usage, tags, categories, license, badges, references, related, or contributors sections.
  * No functional changes to the product; end-user experience remains the same aside from clearer documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->